### PR TITLE
Fix partition unbound variable problem when bios

### DIFF
--- a/arch-install.bash
+++ b/arch-install.bash
@@ -319,8 +319,17 @@ if [[ "$encryption_choice" == "Yes" ]]; then
 fi
 
 genfstab -U /mnt >>/mnt/etc/fstab
+if [[ "$encryption_choice" == "No" ]]; then
+  case "$bios" in
+  'uefi')
+    device_uuid="$(blkid -s UUID -o value "${partitions[1]}")"
+    ;;
+  'legacy')
+    device_uuid="$(blkid -s UUID -o value "${partitions[0]}")"
+    ;;
+  esac
 
-device_uuid="$(blkid -s UUID -o value "${partitions[1]}")"
+fi
 
 export \
   hostname \


### PR DESCRIPTION
This fixes a problem that occurs on legacy systems with no encryption selected. 
We should consider the partitioning in general, as we could just use a boot partition on no encryption and legacy. 

It is out of scope for this pull request, though. This one is only meant to be a hotfix